### PR TITLE
Import classes

### DIFF
--- a/src/myuplink/__init__.py
+++ b/src/myuplink/__init__.py
@@ -1,3 +1,5 @@
-from .api import MyUplinkAPI
-from .auth import Auth
-from .auth_abstract import AbstractAuth
+"""Library for myUplink."""
+from .api import MyUplinkAPI  # noqa: F401
+from .auth import Auth  # noqa: F401
+from .auth_abstract import AbstractAuth  # noqa: F401
+from .models import System, SystemDevice, Device, DevicePoint  # noqa: F401


### PR DESCRIPTION
Import all "global" classes to \_\_init\_\_.py. This simplifies the import statements for modules using this library.