### PR TITLE
Add setter to DevicePoint.value and improve typing

### DIFF
--- a/src/myuplink/models.py
+++ b/src/myuplink/models.py
@@ -210,8 +210,12 @@ class DevicePoint():
         return self.raw_data["timestamp"]
 
     @property
-    def value(self):
+    def value(self) -> str | float | int | None:
         return self.raw_data["value"]
+
+    @value.setter
+    def value(self, new_value: str | float | int | None):
+        self.raw_data["value"] = new_value
 
     @property
     def min_value(self) -> float | None:


### PR DESCRIPTION
This will allow us to set the value of a DataPoint. It is useful after toggling a switch or setting a number entity. We will not have to wait for the DataUpdateCoordinator to refresh data from API and thus save up to 60 s and 3 api calls. 

This PR can be included in 0.4.0 since it is not released yes.