### PR TITLE
Change from List to generic list

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ classifiers =
 package_dir =
     = src
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.9
 install_requires =
     aiohttp >= 3.7.3
 

--- a/src/myuplink/api.py
+++ b/src/myuplink/api.py
@@ -1,5 +1,4 @@
 """Define the MyUplinkAPI class."""
-from typing import List
 
 from .auth import AbstractAuth
 from .models import System, SystemNotification, Device, DevicePoint, Paging
@@ -32,7 +31,7 @@ class MyUplinkAPI:
         else:
             return False
 
-    async def async_get_systems(self) -> List[System]:
+    async def async_get_systems(self) -> list[System]:
         """Return systems."""
         json = await self.async_get_systems_json()
         array = json["systems"]
@@ -57,7 +56,7 @@ class MyUplinkAPI:
 
     async def async_get_device_points(
         self, device_id, language: str = "en-GB"
-    ) -> List[DevicePoint]:
+    ) -> list[DevicePoint]:
         """Return device points."""
         array = await self.async_get_device_points_json(device_id, language)
         return [DevicePoint(point_data) for point_data in array]

--- a/src/myuplink/models.py
+++ b/src/myuplink/models.py
@@ -1,5 +1,5 @@
 """Data models for myuplink."""
-from typing import TypeVar, Generic, List
+from typing import TypeVar, Generic
 from datetime import datetime
 from enum import Enum
 
@@ -13,7 +13,7 @@ class Paging(Generic[T]):
     """Paging object."""
 
     def __init__(
-        self, page_number: int, items_per_page: int, total_items: int, items: List[T]
+        self, page_number: int, items_per_page: int, total_items: int, items: list[T]
     ):
         """Initialize a paging object."""
         self.page_number = page_number
@@ -193,7 +193,7 @@ class System:
         return self.raw_data["country"]
 
     @property
-    def devices(self) -> List[SystemDevice]:
+    def devices(self) -> list[SystemDevice]:
         """Return devices on the system."""
         return [SystemDevice(device_data) for device_data in self.raw_data["devices"]]
 
@@ -368,18 +368,17 @@ class DevicePoint:
         """Return the scaling factor for min and max values."""
         return self.raw_data["scaleValue"]
 
-    @property
-    def enum_values_list(self) -> List[EnumValue]:
+    def enum_values_list(self) -> list[EnumValue]:
         """Return the enumValues as list."""
         return [EnumValue(enum_data) for enum_data in self.raw_data["enumValues"]]
 
     @property
-    def enum_values(self) -> dict:
+    def enum_values(self) -> list[EnumValue]:
         """Return the enumValues as dict."""
         return self.raw_data["enumValues"]
 
     @property
-    def smart_home_categories(self) -> List[str]:
+    def smart_home_categories(self) -> list[str]:
         """Return smart_home_categories as list."""
         return self.raw_data["smartHomeCategories"]
 


### PR DESCRIPTION
I think we should change the type List to the generic list that is available from Python v3.9 or was it 3.8?
May need a rebase after #26 is merged.