### PR TITLE
Add methods to get system names, models, etc

### DIFF
--- a/examples/example_get_names.py
+++ b/examples/example_get_names.py
@@ -1,0 +1,33 @@
+"""List defined zones."""
+import asyncio
+import aiohttp
+
+from myuplink import Auth
+from myuplink import MyUplinkAPI
+from myuplink import get_manufacturer, get_model, get_series, get_system_name
+
+
+async def main():
+    """Print name strings from system and devices."""
+    async with aiohttp.ClientSession() as session:
+        auth = Auth(
+            session,
+            "https://api.myuplink.com",
+            "PUT_YOUR_TOKEN_HERE",
+        )
+        api = MyUplinkAPI(auth)
+
+        systems = await api.async_get_systems()
+        for system in systems:
+            print()
+
+            for device in system.devices:
+                print(f"System name: {get_system_name(system)}")
+                device = await api.async_get_device(device.id)
+                print(f"Product name {device.product_name}")
+                print(f"Model: {get_model(device)}")
+                print(f"Manufacturer: {get_manufacturer(device)}")
+                print(f"Series: {get_series(device)}")
+
+
+asyncio.run(main())

--- a/src/myuplink/__init__.py
+++ b/src/myuplink/__init__.py
@@ -3,3 +3,4 @@ from .api import MyUplinkAPI  # noqa: F401
 from .auth import Auth  # noqa: F401
 from .auth_abstract import AbstractAuth  # noqa: F401
 from .models import System, SystemDevice, Device, DevicePoint, EnumValue  # noqa: F401
+from .names import get_manufacturer, get_model, get_series, get_system_name  # noqa: F401

--- a/src/myuplink/names.py
+++ b/src/myuplink/names.py
@@ -1,0 +1,71 @@
+"""Methods for getting names etc from API data."""
+import re
+from .models import Device, System
+
+
+MAP_NIBEF = {"manufacturer": "Nibe", "series": "F"}
+MAP_NIBES = {"manufacturer": "Nibe", "series": "S"}
+NAME_MAP = {
+    "F1145": MAP_NIBEF,
+    "F1155": MAP_NIBEF,
+    "F1245": MAP_NIBEF,
+    "F1255": MAP_NIBEF,
+    "F1345": MAP_NIBEF,
+    "F1355": MAP_NIBEF,
+    "F370": MAP_NIBEF,
+    "F470": MAP_NIBEF,
+    "F730": MAP_NIBEF,
+    "F750": MAP_NIBEF,
+    "SMO20": MAP_NIBEF,
+    "SMO40": MAP_NIBEF,
+    "VVM225": MAP_NIBEF,
+    "VVM310": MAP_NIBEF,
+    "VVM320": MAP_NIBEF,
+    "VVM325": MAP_NIBEF,
+    "VVM500": MAP_NIBEF,
+    "S1155": MAP_NIBES,
+    "S1255": MAP_NIBES,
+    "S1256": MAP_NIBES,
+    "S320": MAP_NIBES,
+    "S325": MAP_NIBES,
+    "S735": MAP_NIBES,
+    "S2125": MAP_NIBES,
+    "SMOS40": MAP_NIBES,
+}
+
+
+def get_system_name(system: System) -> str | None:
+    """Return system name."""
+    return system.name
+
+
+def get_manufacturer(device: Device) -> str | None:
+    """Return manufacturer name."""
+    print(device.product_name)
+    for model, data in NAME_MAP.items():
+        if re.search(model, device.product_name):
+            return data.get("manufacturer")
+
+    return device.productName.split()[0]
+
+
+def get_model(device: Device) -> str | None:
+    """Return model name."""
+    for model in NAME_MAP:
+        if re.search(model, device.product_name):
+            return model
+    name_list = device.product_name.split()
+    if len(name_list == 0):
+        model = name_list[0]
+    else:
+        model = " ".join(name_list[1:])
+    return model
+
+
+def get_series(device: Device) -> str | None:
+    """Return product series."""
+    for model, data in NAME_MAP.items():
+        if re.search(model, device.product_name):
+            return data.get("series")
+
+    return None


### PR DESCRIPTION
This PR adds methods for getting names, manufacturers etc.
The reason to put these utilities in the lib is that the methods depend on lookup tables that are specific to each manufacturer. It will be easier to maintain outside of HA-core.
If there is no macth in the lookup tables the names are created using best effort from the available data from API.