### PR TITLE
NamesAndReleaseTyping

### DIFF
--- a/examples/example_enum_values.py
+++ b/examples/example_enum_values.py
@@ -4,6 +4,7 @@ import aiohttp
 
 from myuplink.auth import Auth
 from myuplink import MyUplinkAPI
+from my_token import MY_TOKEN
 
 
 async def main():
@@ -11,7 +12,7 @@ async def main():
         auth = Auth(
             session,
             "https://api.myuplink.com",
-            "PUT-YOUR_TOKEN_HERE",
+            MY_TOKEN,
         )
         api = MyUplinkAPI(auth)
 

--- a/examples/example_get_names.py
+++ b/examples/example_get_names.py
@@ -5,6 +5,7 @@ import aiohttp
 from myuplink import Auth
 from myuplink import MyUplinkAPI
 from myuplink import get_manufacturer, get_model, get_series, get_system_name
+from my_token import MY_TOKEN
 
 
 async def main():
@@ -13,7 +14,7 @@ async def main():
         auth = Auth(
             session,
             "https://api.myuplink.com",
-            "PUT_YOUR_TOKEN_HERE",
+            MY_TOKEN,
         )
         api = MyUplinkAPI(auth)
 

--- a/examples/example_zones.py
+++ b/examples/example_zones.py
@@ -4,6 +4,7 @@ import aiohttp
 
 from myuplink.auth import Auth
 from myuplink import MyUplinkAPI
+from my_token import MY_TOKEN
 
 
 async def main():
@@ -11,7 +12,7 @@ async def main():
         auth = Auth(
             session,
             "https://api.myuplink.com",
-            "TOKEN",
+            MY_TOKEN,
         )
         api = MyUplinkAPI(auth)
 
@@ -23,21 +24,23 @@ async def main():
 
             for sysDevice in system.devices:
                 device = await api.async_get_device(sysDevice.deviceId)
-                print(device.id)
-                print(device.productName)
-                print(device.productSerialNumber)
-                print(device.firmwareCurrent)
-                print(device.firmwareDesired)
-                print(device.connectionState)
+                print(f"Device id: {device.id}")
+                print(f"Device productName: {device.productName}")
+                print(f"Device productSerialNumber: {device.productSerialNumber}")
+                print(f"Device productCurrentFirmware: {device.firmwareCurrent}")
+                print(f"Device productDesiredFirmware: {device.firmwareDesired}")
+                print(f"Device connectionState: {device.connectionState}")
 
                 zones = await api.async_get_smart_home_zones(sysDevice.deviceId)
                 if len(zones) == 0:
+                    print()
                     print("No zones defined on device")
                 else:
                     for zone in zones:
-                        print(zone.zone_id)
-                        print(zone.name)
                         print("")
+                        print(f"Zone id: {zone.zone_id}")
+                        print(f"Zone name: {zone.name}")
+                print()
 
 
 asyncio.run(main())

--- a/examples/my_token.py
+++ b/examples/my_token.py
@@ -1,0 +1,7 @@
+"""Store token here.
+
+It is easiest to copy your fresh token from Swagger.
+Paste it here and you are good to go testing for 60 min.
+"""
+# MY_TOKEN = "Paste your token betewwn the quotes"
+MY_TOKEN = ""

--- a/src/myuplink/__init__.py
+++ b/src/myuplink/__init__.py
@@ -3,3 +3,4 @@ from .api import MyUplinkAPI  # noqa: F401
 from .auth import Auth  # noqa: F401
 from .auth_abstract import AbstractAuth  # noqa: F401
 from .models import System, SystemDevice, Device, DevicePoint, EnumValue  # noqa: F401
+from .names import get_model, get_manufacturer, get_series, get_system_name  # noqa:F401

--- a/src/myuplink/models.py
+++ b/src/myuplink/models.py
@@ -424,7 +424,7 @@ class Zone:
         return self.raw_data["zoneId"]
 
     @property
-    def name_id(self) -> str | None:
+    def name(self) -> str | None:
         """Return the name."""
         return self.raw_data["name"]
 

--- a/src/myuplink/models.py
+++ b/src/myuplink/models.py
@@ -338,8 +338,17 @@ class DevicePoint:
         """Return the timestamp."""
         return self.raw_data["timestamp"]
 
+    # todo: Wait with sharp typing until integration is upgraded
+    # change to value_t in integration, when everything is stable
+    # change value() to typed, update lib and then change back to
+    # value() in the intergation
     @property
-    def value(self) -> str | float | int | None:
+    def value(self):
+        """Return the value."""
+        return self.raw_data["value"]
+
+    @property
+    def value_t(self) -> str | float | int | None:
         """Return the value."""
         return self.raw_data["value"]
 
@@ -373,8 +382,11 @@ class DevicePoint:
         """Return the enumValues as list."""
         return [EnumValue(enum_data) for enum_data in self.raw_data["enumValues"]]
 
+    # todo: Don't sharpen typing until integration is updated
+    # @property
+    # def enum_values(self) -> list[EnumValue]
     @property
-    def enum_values(self) -> list[EnumValue]:
+    def enum_values(self):
         """Return the enumValues as dict."""
         return self.raw_data["enumValues"]
 

--- a/src/myuplink/names.py
+++ b/src/myuplink/names.py
@@ -1,0 +1,70 @@
+"""Methods for getting names etc from API data."""
+import re
+from .models import Device, System
+
+
+MAP_NIBEF = {"manufacturer": "Nibe", "series": "F"}
+MAP_NIBES = {"manufacturer": "Nibe", "series": "S"}
+NAME_MAP = {
+    "F1145": MAP_NIBEF,
+    "F1155": MAP_NIBEF,
+    "F1245": MAP_NIBEF,
+    "F1255": MAP_NIBEF,
+    "F1345": MAP_NIBEF,
+    "F1355": MAP_NIBEF,
+    "F370": MAP_NIBEF,
+    "F470": MAP_NIBEF,
+    "F730": MAP_NIBEF,
+    "F750": MAP_NIBEF,
+    "SMO20": MAP_NIBEF,
+    "SMO40": MAP_NIBEF,
+    "VVM225": MAP_NIBEF,
+    "VVM310": MAP_NIBEF,
+    "VVM320": MAP_NIBEF,
+    "VVM325": MAP_NIBEF,
+    "VVM500": MAP_NIBEF,
+    "S1155": MAP_NIBES,
+    "S1255": MAP_NIBES,
+    "S1256": MAP_NIBES,
+    "S320": MAP_NIBES,
+    "S325": MAP_NIBES,
+    "S735": MAP_NIBES,
+    "S2125": MAP_NIBES,
+    "SMOS40": MAP_NIBES,
+}
+
+
+def get_system_name(system: System) -> str | None:
+    """Return system name."""
+    return system.name
+
+
+def get_manufacturer(device: Device) -> str | None:
+    """Return manufacturer name."""
+    for model, data in NAME_MAP.items():
+        if re.search(model, device.product_name):
+            return data.get("manufacturer")
+
+    return device.productName.split()[0]
+
+
+def get_model(device: Device) -> str | None:
+    """Return model name."""
+    for model in NAME_MAP:
+        if re.search(model, device.product_name):
+            return model
+    name_list = device.product_name.split()
+    if len(name_list == 0):
+        model = name_list[0]
+    else:
+        model = " ".join(name_list[1:])
+    return model
+
+
+def get_series(device: Device) -> str | None:
+    """Return product series."""
+    for model, data in NAME_MAP.items():
+        if re.search(model, device.product_name):
+            return data.get("series")
+
+    return None


### PR DESCRIPTION
It was harder than expected to get the stype checking flawless. It seems that the mypy configuration in the devcontainer is slightly less strict than in CI in core repo on GitHub.

This PR includes:
- Removal of a debug print  statement. 
- Relaxed typing in two places in the models
- Added methods for getting names for devices, models and manufacturers from API data.

Please merge if you find it OK. Then we can test the rc and when it is verified to work you can release and I will make a new attempt to create a PR in core.