### PR TITLE
CherryPickPoints

### DIFF
--- a/examples/example_specific_points.py
+++ b/examples/example_specific_points.py
@@ -1,0 +1,48 @@
+"""List defined zones."""
+import asyncio
+import aiohttp
+
+from my_token import MY_TOKEN
+
+from myuplink.auth import Auth
+from myuplink import MyUplinkAPI
+
+PARAMETERS = ["40004", "40940", "40005"]
+
+
+async def main():
+    """Connect and print test data."""
+    async with aiohttp.ClientSession() as session:
+        auth = Auth(
+            session,
+            "https://api.myuplink.com",
+            MY_TOKEN,
+        )
+        api = MyUplinkAPI(auth)
+
+        systems = await api.async_get_systems()
+        for system in systems:
+            print(f"System id: {system.id}")
+            print(f"System name: {system.name}")
+
+            print(f"No of devices in system: {len(system.devices)}")
+            for sys_device in system.devices:
+                device = await api.async_get_device(sys_device.deviceId)
+                print(device.id)
+                print(device.productName)
+                print(device.productSerialNumber)
+                print(device.firmwareCurrent)
+                print(device.firmwareDesired)
+                print(device.connectionState)
+
+                points = await api.async_get_device_points(
+                    sys_device.deviceId, points=PARAMETERS
+                )
+                for point in points:
+                    print(
+                        f"{point.parameter_id} | {point.parameter_name} | {point.value}"
+                    )
+                print()
+
+
+asyncio.run(main())

--- a/src/myuplink/__init__.py
+++ b/src/myuplink/__init__.py
@@ -2,5 +2,15 @@
 from .api import MyUplinkAPI  # noqa: F401
 from .auth import Auth  # noqa: F401
 from .auth_abstract import AbstractAuth  # noqa: F401
-from .models import System, SystemDevice, Device, DevicePoint, EnumValue  # noqa: F401
+from .models import (  # noqa: F401
+    Device,
+    DeviceConnectionState,
+    DevicePoint,
+    EnumValue,
+    Paging,
+    System,
+    SystemDevice,
+    SystemNotification,
+    SystemNotificationStatus,
+)
 from .names import get_model, get_manufacturer, get_series, get_system_name  # noqa:F401

--- a/src/myuplink/api.py
+++ b/src/myuplink/api.py
@@ -55,19 +55,24 @@ class MyUplinkAPI:
         return await resp.json()
 
     async def async_get_device_points(
-        self, device_id, language: str = "en-GB"
+        self, device_id, language: str = "en-GB", points: list[str] | None = None
     ) -> list[DevicePoint]:
         """Return device points."""
-        array = await self.async_get_device_points_json(device_id, language)
+        array = await self.async_get_device_points_json(device_id, language, points)
         return [DevicePoint(point_data) for point_data in array]
 
     async def async_get_device_points_json(
-        self, device_id, language: str = "en-GB"
+        self, device_id, language: str = "en-GB", points: list[str] | None = None
     ) -> dict:
         """Return device points as json."""
         headers = {"Accept-Language": language}
+        if points is None:
+            points = []
+        params = ""
+        if len(points) > 0:
+            params = "?parameters=" + ",".join(points)
         resp = await self.auth.request(
-            "get", f"v2/devices/{device_id}/points", headers=headers
+            "get", f"v2/devices/{device_id}/points{params}", headers=headers
         )
         resp.raise_for_status()
         return await resp.json()


### PR DESCRIPTION
Add optional list of point_id to async_get_device_points.
To be used when api returns excessive number of device points for a device. E.g Nibe SMO 20 returns more than 600 points where the absolute majority are of no interest for HA users.